### PR TITLE
chore: add overrides for all package managers

### DIFF
--- a/next-reown/package.json
+++ b/next-reown/package.json
@@ -11,6 +11,14 @@
   "overrides": {
     "@solana/web3.js": "^1.98.0"
   },
+  "resolutions": {
+    "@solana/web3.js": "^1.98.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@solana/web3.js": "^1.98.0"
+    }
+  },
   "dependencies": {
     "@layerzerolabs/lz-definitions": "^3.0.63",
     "@layerzerolabs/lz-v2-utilities": "^3.0.63",

--- a/next/package.json
+++ b/next/package.json
@@ -11,6 +11,14 @@
   "overrides": {
     "@solana/web3.js": "^1.98.0"
   },
+  "resolutions": {
+    "@solana/web3.js": "^1.98.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@solana/web3.js": "^1.98.0"
+    }
+  },
   "dependencies": {
     "@layerzerolabs/lz-definitions": "^3.0.60",
     "@layerzerolabs/lz-v2-utilities": "^3.0.60",

--- a/vite/package.json
+++ b/vite/package.json
@@ -9,9 +9,15 @@
     "lint": "eslint .",
     "preview": "vite preview"
   },
+  "overrides": {
+    "@solana/web3.js": "^1.98.0"
+  },
+  "resolutions": {
+    "@solana/web3.js": "^1.98.0"
+  },
   "pnpm": {
     "overrides": {
-      "@solana/web3.js": "~1.98.0"
+      "@solana/web3.js": "^1.98.0"
     }
   },
   "dependencies": {


### PR DESCRIPTION
currently the overrides only work if `npm` is used, but it should be applied regardless of which package manager is used